### PR TITLE
Support multi-instance rendering

### DIFF
--- a/View.cpp
+++ b/View.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 using namespace Define;
 
-View::View() : _programId(0), _mod(0), isUseLive2d(true), isUseMask(false)
+View::View() : _programId(0), isUseLive2d(true), isUseMask(false)
 {
     _clearColor[0] = 1.0f;
     _clearColor[1] = 1.0f;
@@ -121,8 +121,8 @@ void View::UpdataViewData(int id) {
 
 int View::TranslateKey(int key, int id)
 {
-	for (int j = 0; j < _viewData[id]._mode[_mod]._keysCount; j++) {
-		if (strcmp(_infoReader->_modeInfo[_mod].KeyUse[j], KeyDefine[key]) == 0)
+	for (int j = 0; j < _viewData[id]._mode[_mod[id]]._keysCount; j++) {
+		if (strcmp(_infoReader->_modeInfo[_mod[id]].KeyUse[j], KeyDefine[key]) == 0)
 			return j;
 	}
 	return -1;
@@ -141,21 +141,21 @@ void View::RenderBackgroud(int id)
 {
 	
 	//render backgroud
-	if (isUseLive2d && _viewData[id]._mode[_mod]._haseModel) {
+	if (isUseLive2d && _viewData[id]._mode[_mod[id]]._haseModel) {
 
-		if (_viewData[id]._mode[_mod]._back)
-			_viewData[id]._mode[_mod]._back->Render(id);
+		if (_viewData[id]._mode[_mod[id]]._back)
+			_viewData[id]._mode[_mod[id]]._back->Render(id);
 
 	} else {
-		if (_viewData[id]._mode[_mod]._catback)
-			_viewData[id]._mode[_mod]._catback->Render(id);
+		if (_viewData[id]._mode[_mod[id]]._catback)
+			_viewData[id]._mode[_mod[id]]._catback->Render(id);
 	}
 }
 
 void View::RenderCat(int id) {
 	Live2DManager *Live2DManager = Live2DManager::GetInstance();
-	if (isUseLive2d && _viewData[id]._mode[_mod]._haseModel) {
-		Live2DManager->OnUpdate(_viewData[id]._mode[_mod]._modelId);
+	if (isUseLive2d && _viewData[id]._mode[_mod[id]]._haseModel) {
+		Live2DManager->OnUpdate(_viewData[id]._mode[_mod[id]]._modelId);
 	}
 }
 
@@ -166,8 +166,8 @@ void View::RenderKeys(int id)
 		if (eventManager->GetKeySignal(i)) {
 			int key = TranslateKey(i, id);
 			if (key != -1) {
-				if (_viewData[id]._mode[_mod]._keys[key])
-					_viewData[id]._mode[_mod]._keys[key]->Render(id);
+				if (_viewData[id]._mode[_mod[id]]._keys[key])
+					_viewData[id]._mode[_mod[id]]._keys[key]->Render(id);
 			}
 		}
 	}
@@ -177,15 +177,15 @@ bool View::RenderLeftHands(int id) {
 
 	Live2DManager *Live2DManager = Live2DManager::GetInstance();
 	bool isUp = true;
-	if (_viewData[id]._mode[_mod]._leftHandsCount > 0) {	
+	if (_viewData[id]._mode[_mod[id]]._leftHandsCount > 0) {	
 		for (int i = 0; i < KeyAmount; i++) {
 			if (eventManager->GetKeySignal(i)) {
 
 				int key = TranslateKey(i, id);
-				if (key != -1 && key < _viewData[id]._mode[_mod]._leftHandsCount) {
+				if (key != -1 && key < _viewData[id]._mode[_mod[id]]._leftHandsCount) {
 
-					if (_viewData[id]._mode[_mod] ._leftHands[key])
-						_viewData[id]._mode[_mod]._leftHands[key]->Render(id);
+					if (_viewData[id]._mode[_mod[id]] ._leftHands[key])
+						_viewData[id]._mode[_mod[id]]._leftHands[key]->Render(id);
 
 					isUp = false;
 					break; //cat only have one right hand
@@ -193,9 +193,9 @@ bool View::RenderLeftHands(int id) {
 			}
 		}
 
-	} else if (_viewData[id]._mode[_mod]._hasLeftHandModel) {
+	} else if (_viewData[id]._mode[_mod[id]]._hasLeftHandModel) {
 		if (!isUseLive2d) {	
-			Live2DManager->OnUpdate(_viewData[id]._mode[_mod]._leftHandModelId);
+			Live2DManager->OnUpdate(_viewData[id]._mode[_mod[id]]._leftHandModelId);
 		}
 		isUp = false;		
 	} else if (isUseLive2d)
@@ -208,25 +208,25 @@ bool View::RenderRightHands(int id) {
 
 	Live2DManager *Live2DManager = Live2DManager::GetInstance();
 	bool isUp = true;
-	if (_viewData[id]._mode[_mod]._rightHandsCount > 0) {
+	if (_viewData[id]._mode[_mod[id]]._rightHandsCount > 0) {
 		
 
 		for (int i = 0; i < KeyAmount; i++) {
 			if (eventManager->GetKeySignal(i)) {
-				int key = TranslateKey(i, id) - _viewData[id]._mode[_mod]._leftHandsCount;
+				int key = TranslateKey(i, id) - _viewData[id]._mode[_mod[id]]._leftHandsCount;
 
-				if (key >= 0 && key < _viewData[id]._mode[_mod]._rightHandsCount) {
+				if (key >= 0 && key < _viewData[id]._mode[_mod[id]]._rightHandsCount) {
 
-					if (_viewData[id]._mode[_mod]._rightHands[key])
-						_viewData[id]._mode[_mod]._rightHands[key]->Render(id);
+					if (_viewData[id]._mode[_mod[id]]._rightHands[key])
+						_viewData[id]._mode[_mod[id]]._rightHands[key]->Render(id);
 					isUp = false;
 					break; //cat only have one right hand
 				}
 			}
 		}			
-	} else if (_viewData[id]._mode[_mod]._hasRightHandModel) {	
+	} else if (_viewData[id]._mode[_mod[id]]._hasRightHandModel) {	
 		if (!isUseLive2d) {	
-			Live2DManager->OnUpdate(_viewData[id]._mode[_mod]._rightHandModelId);
+			Live2DManager->OnUpdate(_viewData[id]._mode[_mod[id]]._rightHandModelId);
 		}
 		isUp = false;	
 	} else if (isUseLive2d)
@@ -237,12 +237,12 @@ bool View::RenderRightHands(int id) {
 
 void View::RenderUphands(bool leftup, bool righttup, int id) {
 	if (leftup) {
-		if (_viewData[id]._mode[_mod]._leftHandUp)
-			_viewData[id]._mode[_mod]._leftHandUp->Render(id);
+		if (_viewData[id]._mode[_mod[id]]._leftHandUp)
+			_viewData[id]._mode[_mod[id]]._leftHandUp->Render(id);
 	}
 	if (righttup) {
-		if (_viewData[id]._mode[_mod]._rightHandUp)
-			_viewData[id]._mode[_mod]._rightHandUp->Render(id);
+		if (_viewData[id]._mode[_mod[id]]._rightHandUp)
+			_viewData[id]._mode[_mod[id]]._rightHandUp->Render(id);
 	}
 
 }
@@ -260,8 +260,6 @@ void View::ReanderMask(int id) {
 	if (isUseMask&&_viewData[id]._face[_viewData[id]._curentface])
 		  _viewData[id]._face[_viewData[id]._curentface]->Render(id);
 }
-
-void View::ChangeMode(int mod, int id) {}
 
 void View::Render(int id)
 {
@@ -596,9 +594,9 @@ void View::Update( bool _isLive2D, bool _isUseMask) {
 	isUseMask = _isUseMask;
 }
 
-void View::setMod(uint16_t i)
+void View::setMod(uint16_t i, int id)
 {
-	_mod = i;
+	_mod[id] = i;
 }
 
 

--- a/View.hpp
+++ b/View.hpp
@@ -123,7 +123,7 @@ public:
 
      void Update(bool _isLive2D,bool _isUseMask);
 
-     void setMod(uint16_t i);
+     void setMod(uint16_t i, int id);
 
 private:
     void UpdataViewData(int id);
@@ -146,11 +146,9 @@ private:
 
     void ReanderMask(int id);
 
-    void ChangeMode(int mod, int id);
+    ViewData _viewData[MAXVIEWDATA] = {};
 
-    ViewData _viewData[MAXVIEWDATA];
-
-    uint16_t _mod;
+    uint16_t _mod[MAXVIEWDATA] = {};
     bool isUseLive2d;
     bool isUseMask;
 

--- a/VtuberDelegate.cpp
+++ b/VtuberDelegate.cpp
@@ -96,11 +96,8 @@ bool VtuberDelegate::Initialize(int id)
 	    _hook = new Hook();
 	    _hook->Strat();
     
+	    InitializeCubism();
     }
-    
-    
-    // Cubism SDK の初期化
-    InitializeCubism();
 
     _view->InitializeSpirite(id);
     _view->InitializeModel(id);
@@ -172,7 +169,7 @@ void VtuberDelegate::ChangeMode(const char *_mode,bool _live2d,bool _isUseMask, 
 	for (int i = 0; i < _infoReader->ModeCount; i++) {
 		const char *a = _infoReader->ModePath[i];
 		if (strcmp(_mode, _infoReader->ModePath[i]) == 0) {
-			_view->setMod(i);
+			_view->setMod(i, id);
 			
 		}			
 	}

--- a/VtuberFrameWork.cpp
+++ b/VtuberFrameWork.cpp
@@ -8,7 +8,7 @@
 namespace {
     static bool isLoad;
 
-    static bool isInit;
+    static bool isInit[1024];
 
     static int initCount = 0;
     }
@@ -16,9 +16,6 @@ namespace {
 void VtuberFrameWork::InitVtuber(int id)
 {
     initCount++;
-    if (initCount == 0) {
-	isInit = false;
-    }
     isLoad = VtuberDelegate::GetInstance()->LoadResource(id);
 }
 
@@ -27,8 +24,8 @@ void VtuberFrameWork::ReanderVtuber(int targatid, char *data, int bufferWidth,
 {
     if (isLoad) {
     
-    if (initCount>0 && !isInit) {
-	    isInit = true;
+    if (initCount>0 && !isInit[targatid]) {
+	    isInit[targatid] = true;
 	    VtuberDelegate::GetInstance()->Initialize(targatid);
     }
 
@@ -41,9 +38,9 @@ void VtuberFrameWork::ReanderVtuber(int targatid, char *data, int bufferWidth,
 void VtuberFrameWork::UinitVtuber(int id)
 {   
     initCount--;
-    if (initCount == 0 && isInit) {
-	    VtuberDelegate::GetInstance()->ReleaseResource(id);
-	    isInit = false;
+	VtuberDelegate::GetInstance()->ReleaseResource(id);
+	isInit[id] = false;
+    if (initCount == 0) {
 	    VtuberDelegate::GetInstance()->Release();
 	    VtuberDelegate::ReleaseInstance();
     }

--- a/VtuberPlugin.cpp
+++ b/VtuberPlugin.cpp
@@ -23,9 +23,10 @@ const char * VtuberPlugin::VtuberPlugin::VtuberGetName(void *unused)
 void * VtuberPlugin::VtuberPlugin::VtuberCreate(obs_data_t *settings,
 							   obs_source_t *source)
 {
+	static int id = 0;
 	Vtuber_data *vtb = (Vtuber_data *)malloc(sizeof(Vtuber_data));
 	vtb->source = source;
-	vtb->modelId = 0;
+	vtb->modelId = id++;
 
 	double x = obs_data_get_double(settings, "x");
 	double y = obs_data_get_double(settings, "y");
@@ -58,7 +59,7 @@ void VtuberPlugin::VtuberPlugin::VtuberDestroy(void *data)
 	
 	Vtuber_data *spv = (Vtuber_data *)data;
 
-	VtuberFrameWork::UinitVtuber(0);
+	VtuberFrameWork::UinitVtuber(spv->modelId);
 
 	delete spv;
 }


### PR DESCRIPTION
This commit makes it use different IDs for different instances of the plugin, so that users can create multiple sources with different configurations and use them simultaneously: 
![image](https://user-images.githubusercontent.com/4059044/147866836-df761382-93e8-4415-a88c-eec56311ce20.png)
